### PR TITLE
fix: golang printf lint error

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -71,7 +71,7 @@ func BuildDockerImage(ctx context.Context, dockerfile string, tags []string, pus
 			return err
 		}
 		if dockerLogLine.Stream != "" {
-			fmt.Printf(dockerLogLine.Stream)
+			fmt.Print(dockerLogLine.Stream)
 		}
 		if dockerLogLine.Aux != nil {
 			fmt.Printf("Image ID: %s\n", dockerLogLine.Aux.ID)


### PR DESCRIPTION
This is a small change, mainly switching `fmt.printf` with `fmt.print` to fix the following:

While building a new docker image for Stride, [the lint step is failing](https://github.com/p2p-org/cosmos-heighliner/actions/runs/10487194375/job/29047030143) as `printf` is specified without formatting

P.S. In the GH actions output there are no enough details, but running the lint locally makes it clear:
```
docker/docker.go:74:15: printf: non-constant format string in call to fmt.Printf (govet)
			fmt.Printf(dockerLogLine.Stream)
```

			