### PR TITLE
fix: failed builds due to wasmvm library filename

### DIFF
--- a/.github/workflows/cosmoshub.yml
+++ b/.github/workflows/cosmoshub.yml
@@ -45,18 +45,11 @@ jobs:
       - name: Manually pull the base Docker image
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          docker pull ghcr.io/p2p-org/cosmos-heighliner:cosmoshub-v18.1.0
-
-      - name: Pull gaiad binary
-        run: |
-          cd temp/
-          wget https://github.com/cosmos/gaia/releases/download/v19.1.0/gaiad-v19.1.0-linux-amd64
+          docker pull ghcr.io/p2p-org/cosmos-heighliner:infra-toolkit-${{ env.INFRA_TOOLKIT }}
 
       - name: Build and push cosmoshub Docker image
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          cd temp/
-          docker build -t gaia:${{ env.VERSION }} .
+          ./heighliner build -c gaia --git-ref ${{ env.VERSION }}
 
       - name: Tag and push Docker image
         run: |

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -6,13 +6,13 @@ RUN apk add --update --no-cache curl make git libc-dev bash gcc linux-headers eu
 ARG CLONE_KEY
 
 RUN if [ ! -z "${CLONE_KEY}" ]; then\
-  mkdir -p ~/.ssh;\
-  echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
-  chmod 600 ~/.ssh/id_ed25519;\
-  apk add openssh;\
-  git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
-  ssh-keyscan github.com >> ~/.ssh/known_hosts;\
-  fi
+        mkdir -p ~/.ssh;\
+        echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
+        chmod 600 ~/.ssh/id_ed25519;\
+        apk add openssh;\
+        git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
+        ssh-keyscan github.com >> ~/.ssh/known_hosts;\
+    fi
 
 ARG TARGETARCH
 ARG BUILDARCH
@@ -37,22 +37,22 @@ ARG BUILD_DIR
 ARG WASMVM_VERSION
 
 RUN set -eux;\
-  export ARCH=$(uname -m);\
-  if [ ! -z "${WASMVM_VERSION}" ]; then\
-  WASMVM_REPO=$(echo $WASMVM_VERSION | awk '{print $1}');\
-  WASMVM_VERS=$(echo $WASMVM_VERSION | awk '{print $2}');\
-  wget -O /lib/libwasmvm_muslc.a https://${WASMVM_REPO}/releases/download/${WASMVM_VERS}/libwasmvm_muslc.$(uname -m).a;\
-  cp /lib/libwasmvm_muslc.a /lib/libwasmvm_muslc.$(uname -m).a;\
-  cp /lib/libwasmvm_muslc.a /lib/libwasmvm.$(uname -m).a;\
-  fi;\
-  export CGO_ENABLED=1 LDFLAGS='-linkmode external -extldflags "-static"';\
-  if [ ! -z "$PRE_BUILD" ]; then sh -c "${PRE_BUILD}"; fi;\
-  if [ ! -z "$BUILD_TARGET" ]; then\
-  if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi;\
-  if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi;\
-  if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi;\
-  sh -c "${BUILD_TARGET}";\
-  fi
+    export ARCH=$(uname -m);\
+    if [ ! -z "${WASMVM_VERSION}" ]; then\
+      WASMVM_REPO=$(echo $WASMVM_VERSION | awk '{print $1}');\
+      WASMVM_VERS=$(echo $WASMVM_VERSION | awk '{print $2}');\
+      wget -O /lib/libwasmvm_muslc.a https://${WASMVM_REPO}/releases/download/${WASMVM_VERS}/libwasmvm_muslc.$(uname -m).a;\
+      cp /lib/libwasmvm_muslc.a /lib/libwasmvm_muslc.$(uname -m).a;\
+      cp /lib/libwasmvm_muslc.a /lib/libwasmvm.$(uname -m).a;\
+    fi;\
+    export CGO_ENABLED=1 LDFLAGS='-linkmode external -extldflags "-static"';\
+    if [ ! -z "$PRE_BUILD" ]; then sh -c "${PRE_BUILD}"; fi;\
+    if [ ! -z "$BUILD_TARGET" ]; then\
+      if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi;\
+      if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi;\
+      if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi;\
+      sh -c "${BUILD_TARGET}";\
+    fi
 
 # Copy all binaries to /root/bin, for a single place to copy into final image.
 # If a colon (:) delimiter is present, binary will be renamed to the text after the delimiter.
@@ -64,28 +64,28 @@ RUN bash -c 'set -eux;\
   BINARIES_ARR=();\
   IFS=, read -ra BINARIES_ARR <<< "$BINARIES_ENV";\
   for BINARY in "${BINARIES_ARR[@]}"; do\
-  BINSPLIT=();\
-  IFS=: read -ra BINSPLIT <<< "$BINARY";\
-  BINPATH=${BINSPLIT[1]+"${BINSPLIT[1]}"};\
-  BIN="$(eval "echo "${BINSPLIT[0]+"${BINSPLIT[0]}"}"")";\
-  if [ ! -z "$RACE" ] && GOVERSIONOUT=$(go version -m $BIN); then\
-  if echo $GOVERSIONOUT | grep build | grep "-race=true"; then\
-  echo "Race detection is enabled in binary";\
-  else\
-  echo "Race detection not enabled in binary!";\
-  exit 1;\
-  fi;\
-  fi;\
-  if [ ! -z "$BINPATH" ]; then\
-  if [[ $BINPATH == *"/"* ]]; then\
-  mkdir -p "$(dirname "${BINPATH}")";\
-  cp "$BIN" "${BINPATH}"; \
-  else \
-  cp "$BIN" "/root/bin/${BINPATH}";\
-  fi;\
-  else\
-  cp "$BIN" /root/bin/;\
-  fi;\
+    BINSPLIT=();\
+    IFS=: read -ra BINSPLIT <<< "$BINARY";\
+    BINPATH=${BINSPLIT[1]+"${BINSPLIT[1]}"};\
+    BIN="$(eval "echo "${BINSPLIT[0]+"${BINSPLIT[0]}"}"")";\
+    if [ ! -z "$RACE" ] && GOVERSIONOUT=$(go version -m $BIN); then\
+      if echo $GOVERSIONOUT | grep build | grep "-race=true"; then\
+        echo "Race detection is enabled in binary";\
+      else\
+        echo "Race detection not enabled in binary!";\
+        exit 1;\
+      fi;\
+    fi;\
+    if [ ! -z "$BINPATH" ]; then\
+      if [[ $BINPATH == *"/"* ]]; then\
+        mkdir -p "$(dirname "${BINPATH}")";\
+        cp "$BIN" "${BINPATH}"; \
+      else \
+        cp "$BIN" "/root/bin/${BINPATH}";\
+      fi;\
+    else\
+      cp "$BIN" /root/bin/;\
+    fi;\
   done'
 
 RUN mkdir -p /root/lib

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -6,13 +6,13 @@ RUN apk add --update --no-cache curl make git libc-dev bash gcc linux-headers eu
 ARG CLONE_KEY
 
 RUN if [ ! -z "${CLONE_KEY}" ]; then\
-        mkdir -p ~/.ssh;\
-        echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
-        chmod 600 ~/.ssh/id_ed25519;\
-        apk add openssh;\
-        git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
-        ssh-keyscan github.com >> ~/.ssh/known_hosts;\
-    fi
+  mkdir -p ~/.ssh;\
+  echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
+  chmod 600 ~/.ssh/id_ed25519;\
+  apk add openssh;\
+  git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
+  ssh-keyscan github.com >> ~/.ssh/known_hosts;\
+  fi
 
 ARG TARGETARCH
 ARG BUILDARCH
@@ -37,20 +37,22 @@ ARG BUILD_DIR
 ARG WASMVM_VERSION
 
 RUN set -eux;\
-    export ARCH=$(uname -m);\
-    if [ ! -z "${WASMVM_VERSION}" ]; then\
-      WASMVM_REPO=$(echo $WASMVM_VERSION | awk '{print $1}');\
-      WASMVM_VERS=$(echo $WASMVM_VERSION | awk '{print $2}');\
-      wget -O /lib/libwasmvm_muslc.a https://${WASMVM_REPO}/releases/download/${WASMVM_VERS}/libwasmvm_muslc.$(uname -m).a;\
-    fi;\
-    export CGO_ENABLED=1 LDFLAGS='-linkmode external -extldflags "-static"';\
-    if [ ! -z "$PRE_BUILD" ]; then sh -c "${PRE_BUILD}"; fi;\
-    if [ ! -z "$BUILD_TARGET" ]; then\
-      if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi;\
-      if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi;\
-      if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi;\
-      sh -c "${BUILD_TARGET}";\
-    fi
+  export ARCH=$(uname -m);\
+  if [ ! -z "${WASMVM_VERSION}" ]; then\
+  WASMVM_REPO=$(echo $WASMVM_VERSION | awk '{print $1}');\
+  WASMVM_VERS=$(echo $WASMVM_VERSION | awk '{print $2}');\
+  wget -O /lib/libwasmvm_muslc.a https://${WASMVM_REPO}/releases/download/${WASMVM_VERS}/libwasmvm_muslc.$(uname -m).a;\
+  cp /lib/libwasmvm_muslc.a /lib/libwasmvm_muslc.$(uname -m).a;\
+  cp /lib/libwasmvm_muslc.a /lib/libwasmvm.$(uname -m).a;\
+  fi;\
+  export CGO_ENABLED=1 LDFLAGS='-linkmode external -extldflags "-static"';\
+  if [ ! -z "$PRE_BUILD" ]; then sh -c "${PRE_BUILD}"; fi;\
+  if [ ! -z "$BUILD_TARGET" ]; then\
+  if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi;\
+  if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi;\
+  if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi;\
+  sh -c "${BUILD_TARGET}";\
+  fi
 
 # Copy all binaries to /root/bin, for a single place to copy into final image.
 # If a colon (:) delimiter is present, binary will be renamed to the text after the delimiter.
@@ -62,28 +64,28 @@ RUN bash -c 'set -eux;\
   BINARIES_ARR=();\
   IFS=, read -ra BINARIES_ARR <<< "$BINARIES_ENV";\
   for BINARY in "${BINARIES_ARR[@]}"; do\
-    BINSPLIT=();\
-    IFS=: read -ra BINSPLIT <<< "$BINARY";\
-    BINPATH=${BINSPLIT[1]+"${BINSPLIT[1]}"};\
-    BIN="$(eval "echo "${BINSPLIT[0]+"${BINSPLIT[0]}"}"")";\
-    if [ ! -z "$RACE" ] && GOVERSIONOUT=$(go version -m $BIN); then\
-      if echo $GOVERSIONOUT | grep build | grep "-race=true"; then\
-        echo "Race detection is enabled in binary";\
-      else\
-        echo "Race detection not enabled in binary!";\
-        exit 1;\
-      fi;\
-    fi;\
-    if [ ! -z "$BINPATH" ]; then\
-      if [[ $BINPATH == *"/"* ]]; then\
-        mkdir -p "$(dirname "${BINPATH}")";\
-        cp "$BIN" "${BINPATH}"; \
-      else \
-        cp "$BIN" "/root/bin/${BINPATH}";\
-      fi;\
-    else\
-      cp "$BIN" /root/bin/;\
-    fi;\
+  BINSPLIT=();\
+  IFS=: read -ra BINSPLIT <<< "$BINARY";\
+  BINPATH=${BINSPLIT[1]+"${BINSPLIT[1]}"};\
+  BIN="$(eval "echo "${BINSPLIT[0]+"${BINSPLIT[0]}"}"")";\
+  if [ ! -z "$RACE" ] && GOVERSIONOUT=$(go version -m $BIN); then\
+  if echo $GOVERSIONOUT | grep build | grep "-race=true"; then\
+  echo "Race detection is enabled in binary";\
+  else\
+  echo "Race detection not enabled in binary!";\
+  exit 1;\
+  fi;\
+  fi;\
+  if [ ! -z "$BINPATH" ]; then\
+  if [[ $BINPATH == *"/"* ]]; then\
+  mkdir -p "$(dirname "${BINPATH}")";\
+  cp "$BIN" "${BINPATH}"; \
+  else \
+  cp "$BIN" "/root/bin/${BINPATH}";\
+  fi;\
+  else\
+  cp "$BIN" /root/bin/;\
+  fi;\
   done'
 
 RUN mkdir -p /root/lib

--- a/temp/Dockerfile
+++ b/temp/Dockerfile
@@ -1,7 +1,0 @@
-FROM ghcr.io/p2p-org/cosmos-heighliner:cosmoshub-v18.1.0
-
-# Copy the new gaiad binary into the container
-COPY ./gaiad-v19.1.0-linux-amd64 /bin/gaiad
-
-# Ensure the binary is executable
-RUN chmod +x /bin/gaiad


### PR DESCRIPTION
This fixes the following build issues:
for v2 (needed for gaia v19 build):
```
/usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: cannot find -lwasmvm_muslc.aarch64: No such file or directory
```
for v1 (needed for stride v22 build):
```
/usr/lib/gcc/aarch64-alpine-linux-musl/13.2.1/../../../../aarch64-alpine-linux-musl/bin/ld: cannot find -lwasmvm.aarch64: No such file or directory
```

And also reverts the workaround of building cosmoshub off older image