### PR TITLE
feat: Add basic go build type

### DIFF
--- a/.github/workflows/jester.yml
+++ b/.github/workflows/jester.yml
@@ -1,0 +1,57 @@
+name: Build and Push jester Docker Image
+
+on:
+  push:
+    tags:
+      - "jester-v[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  INFRA_TOOLKIT: v0.1.6
+
+jobs:
+  build-and-push-jester:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.24.1'
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Heighliner binary
+        run: |
+          go build -o heighliner
+
+      - name: Extract version from tag
+        id: extract_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/jester-}" >> $GITHUB_ENV
+
+      - name: Manually pull the base Docker image
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker pull ghcr.io/p2p-org/cosmos-heighliner:infra-toolkit-${{ env.INFRA_TOOLKIT }}
+
+      - name: Build and push jester Docker image
+        run: |
+          ./heighliner build -c jester --git-ref ${{ env.VERSION }}
+
+      - name: Tag and push Docker image
+        run: |
+          docker tag jester:${{ env.VERSION }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:jester-${{ env.VERSION }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:jester-${{ env.VERSION }}

--- a/builder/types.go
+++ b/builder/types.go
@@ -7,6 +7,7 @@ const (
 	DockerfileTypeAvalanche DockerfileType = "avalanche"
 	DockerfileTypeCargo     DockerfileType = "cargo"
 	DockerfileTypeImported  DockerfileType = "imported"
+	DockerfileTypeGoBuild   DockerfileType = "go-build"
 
 	DockerfileTypeGo   DockerfileType = "go"   // DEPRECATED, use "cosmos" instead
 	DockerfileTypeRust DockerfileType = "rust" // DEPRECATED, use "cargo" instead

--- a/chains/jester.yaml
+++ b/chains/jester.yaml
@@ -1,0 +1,8 @@
+# Jester
+- name: jester
+  github-organization: noble-assets
+  github-repo: jester
+  dockerfile: go-build
+  build-target: make install
+  binaries:
+    - /go/bin/jesterd

--- a/dockerfile/dockerfiles.go
+++ b/dockerfile/dockerfiles.go
@@ -31,3 +31,9 @@ var Cargo []byte
 
 //go:embed cargo/native.Dockerfile
 var CargoNative []byte
+
+//go:embed go-build/Dockerfile
+var GoBuild []byte
+
+//go:embed go-build/native.Dockerfile
+var GoBuildNative []byte

--- a/dockerfile/go-build/Dockerfile
+++ b/dockerfile/go-build/Dockerfile
@@ -1,0 +1,122 @@
+ARG BASE_VERSION
+FROM golang:${BASE_VERSION} AS build-env
+
+# Install minimal build dependencies
+RUN apk add --update --no-cache git make bash
+
+ARG CLONE_KEY
+
+RUN if [ ! -z "${CLONE_KEY}" ]; then\
+        mkdir -p ~/.ssh;\
+        echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
+        chmod 600 ~/.ssh/id_ed25519;\
+        apk add openssh;\
+        git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
+        ssh-keyscan github.com >> ~/.ssh/known_hosts;\
+    fi
+
+ARG TARGETARCH
+ARG BUILDARCH
+ARG GITHUB_ORGANIZATION
+ARG REPO_HOST
+
+WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}
+
+ARG GITHUB_REPO
+ARG VERSION
+ARG BUILD_TIMESTAMP
+
+RUN git clone -b ${VERSION} --single-branch https://${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git --recursive
+
+WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}
+
+ARG BUILD_TARGET
+ARG BUILD_ENV
+ARG BUILD_TAGS
+ARG PRE_BUILD
+ARG BUILD_DIR
+
+# Build with static linking - no external dependencies
+RUN set -eux;\
+    export CGO_ENABLED=0;\
+    export GOOS=linux;\
+    export GOARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/');\
+    if [ ! -z "$PRE_BUILD" ]; then sh -c "${PRE_BUILD}"; fi;\
+    if [ ! -z "$BUILD_TARGET" ]; then\
+      if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi;\
+      if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi;\
+      if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi;\
+      sh -c "${BUILD_TARGET}";\
+    fi
+
+# Copy all binaries to /root/bin
+RUN mkdir /root/bin
+ARG BINARIES
+ENV BINARIES_ENV ${BINARIES}
+RUN bash -c 'set -eux;\
+  BINARIES_ARR=();\
+  IFS=, read -ra BINARIES_ARR <<< "$BINARIES_ENV";\
+  for BINARY in "${BINARIES_ARR[@]}"; do\
+    BINSPLIT=();\
+    IFS=: read -ra BINSPLIT <<< "$BINARY";\
+    BINPATH=${BINSPLIT[1]+"${BINSPLIT[1]}"};\
+    BIN="$(eval "echo "${BINSPLIT[0]+"${BINSPLIT[0]}"}"")";\
+    if [ ! -z "$BINPATH" ]; then\
+      if [[ $BINPATH == *"/"* ]]; then\
+        mkdir -p "$(dirname "${BINPATH}")";\
+        cp "$BIN" "${BINPATH}"; \
+      else \
+        cp "$BIN" "/root/bin/${BINPATH}";\
+      fi;\
+    else\
+      cp "$BIN" /root/bin/;\
+    fi;\
+  done'
+
+# Copy over directories if needed
+RUN mkdir -p /root/dir_abs && touch /root/dir_abs.list
+ARG DIRECTORIES
+ENV DIRECTORIES_ENV ${DIRECTORIES}
+RUN bash -c 'set -eux;\
+  DIRECTORIES_ARR=($DIRECTORIES_ENV);\
+  i=0;\
+  for DIRECTORY in "${DIRECTORIES_ARR[@]}"; do \
+    cp -R $DIRECTORY /root/dir_abs/$i;\
+    echo $DIRECTORY >> /root/dir_abs.list;\
+    ((i = i + 1));\
+  done'
+
+# Final image - use alpine for simplicity
+FROM alpine:3
+
+LABEL org.opencontainers.image.source="https://github.com/p2p-org/cosmos-heighliner"
+
+# Install basic utilities
+RUN apk add --update --no-cache ca-certificates
+
+# Create p2p user
+RUN addgroup --gid 1111 -S p2p && adduser --uid 1111 -S p2p -G p2p
+
+WORKDIR /bin
+
+# Copy over absolute path directories
+COPY --from=build-env /root/dir_abs /root/dir_abs
+COPY --from=build-env /root/dir_abs.list /root/dir_abs.list
+
+# Move absolute path directories to their absolute locations.
+RUN sh -c 'i=0; while read DIR; do\
+      echo "$i: $DIR";\
+      PLACEDIR="$(dirname "$DIR")";\
+      mkdir -p "$PLACEDIR";\
+      mv /root/dir_abs/$i $DIR;\
+      i=$((i+1));\
+    done < /root/dir_abs.list'
+
+# Install chain binaries
+COPY --from=build-env /root/bin /bin
+
+# Clean up
+RUN rm -rf /root/dir_abs /root/dir_abs.list
+
+WORKDIR /home/p2p
+USER p2p

--- a/dockerfile/go-build/native.Dockerfile
+++ b/dockerfile/go-build/native.Dockerfile
@@ -1,0 +1,170 @@
+ARG BASE_VERSION
+FROM golang:${BASE_VERSION} AS build-env
+
+# Install minimal build dependencies
+RUN apk add --update --no-cache git make bash
+
+ARG CLONE_KEY
+
+RUN if [ ! -z "${CLONE_KEY}" ]; then\
+        mkdir -p ~/.ssh;\
+        echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
+        chmod 600 ~/.ssh/id_ed25519;\
+        apk add openssh;\
+        git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
+        ssh-keyscan github.com >> ~/.ssh/known_hosts;\
+    fi
+
+ARG TARGETARCH
+ARG BUILDARCH
+ARG GITHUB_ORGANIZATION
+ARG REPO_HOST
+
+WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}
+
+ARG GITHUB_REPO
+ARG VERSION
+ARG BUILD_TIMESTAMP
+
+RUN git clone -b ${VERSION} --single-branch https://${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}.git --recursive
+
+WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}
+
+ARG BUILD_TARGET
+ARG BUILD_ENV
+ARG BUILD_TAGS
+ARG PRE_BUILD
+ARG BUILD_DIR
+
+# Build with static linking - no external dependencies
+RUN set -eux;\
+    export CGO_ENABLED=0;\
+    export GOOS=linux;\
+    export GOARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/');\
+    if [ ! -z "$PRE_BUILD" ]; then sh -c "${PRE_BUILD}"; fi;\
+    if [ ! -z "$BUILD_TARGET" ]; then\
+      if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi;\
+      if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi;\
+      if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi;\
+      sh -c "${BUILD_TARGET}";\
+    fi
+
+# Copy all binaries to /root/bin
+RUN mkdir /root/bin
+ARG BINARIES
+ENV BINARIES_ENV ${BINARIES}
+RUN bash -c 'set -eux;\
+  BINARIES_ARR=();\
+  IFS=, read -ra BINARIES_ARR <<< "$BINARIES_ENV";\
+  for BINARY in "${BINARIES_ARR[@]}"; do\
+    BINSPLIT=();\
+    IFS=: read -ra BINSPLIT <<< "$BINARY";\
+    BINPATH=${BINSPLIT[1]+"${BINSPLIT[1]}"};\
+    BIN="$(eval "echo "${BINSPLIT[0]+"${BINSPLIT[0]}"}"")";\
+    if [ ! -z "$BINPATH" ]; then\
+      if [[ $BINPATH == *"/"* ]]; then\
+        mkdir -p "$(dirname "${BINPATH}")";\
+        cp "$BIN" "${BINPATH}"; \
+      else \
+        cp "$BIN" "/root/bin/${BINPATH}";\
+      fi;\
+    else\
+      cp "$BIN" /root/bin/;\
+    fi;\
+  done'
+
+# Copy over directories if needed
+RUN mkdir -p /root/dir_abs && touch /root/dir_abs.list
+ARG DIRECTORIES
+ENV DIRECTORIES_ENV ${DIRECTORIES}
+RUN bash -c 'set -eux;\
+  DIRECTORIES_ARR=($DIRECTORIES_ENV);\
+  i=0;\
+  for DIRECTORY in "${DIRECTORIES_ARR[@]}"; do \
+    cp -R $DIRECTORY /root/dir_abs/$i;\
+    echo $DIRECTORY >> /root/dir_abs.list;\
+    ((i = i + 1));\
+  done'
+
+# Use minimal busybox from infra-toolkit image for final scratch image
+FROM ghcr.io/p2p-org/cosmos-heighliner:infra-toolkit-v0.1.6 AS infra-toolkit
+RUN addgroup --gid 1111 -S p2p && adduser --uid 1111 -S p2p -G p2p
+
+# Use ln and rm from full featured busybox for assembling final image
+FROM busybox:1.34.1-musl AS busybox-full
+
+# Use alpine to source the latest CA certificates
+FROM alpine:3 as alpine-3
+
+# Build final image from scratch
+FROM scratch
+
+LABEL org.opencontainers.image.source="https://github.com/p2p-org/cosmos-heighliner"
+
+WORKDIR /bin
+
+# Install ln (for making hard links), rm (for cleanup), mv, mkdir, vi and dirname from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/vi /bin/dirname ./
+
+# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
+
+# Install jq
+COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
+# Add hard links for read-only utils
+# Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
+RUN for b in \
+  cat \
+  date \
+  df \
+  du \
+  env \
+  grep \
+  head \
+  less \
+  ls \
+  md5sum \
+  pwd \
+  sha1sum \
+  sha256sum \
+  sha3sum \
+  sha512sum \
+  sleep \
+  stty \
+  tail \
+  tar \
+  tee \
+  tr \
+  watch \
+  which \
+  ; do ln sh $b; done
+
+# Copy over absolute path directories
+COPY --from=build-env /root/dir_abs /root/dir_abs
+COPY --from=build-env /root/dir_abs.list /root/dir_abs.list
+
+# Move absolute path directories to their absolute locations.
+RUN sh -c 'i=0; while read DIR; do\
+      echo "$i: $DIR";\
+      PLACEDIR="$(dirname "$DIR")";\
+      mkdir -p "$PLACEDIR";\
+      mv /root/dir_abs/$i $DIR;\
+      i=$((i+1));\
+    done < /root/dir_abs.list'
+
+# Install chain binaries
+COPY --from=build-env /root/bin /bin
+
+# Install trusted CA certificates
+COPY --from=alpine-3 /etc/ssl/cert.pem /etc/ssl/cert.pem
+
+# Install heighliner user
+COPY --from=infra-toolkit /etc/passwd /etc/passwd
+COPY --from=infra-toolkit --chown=1111:1111 /home/p2p /home/p2p
+
+# Remove write utils used to construct image and tmp dir/file for lib copy.
+RUN rm -rf ln dirname /root/dir_abs /root/dir_abs.list
+
+WORKDIR /home/p2p
+# USER p2p


### PR DESCRIPTION
This is adds a basic go build type without cosmos dependencies (libwasm, etc)

To be used for sidecars that need to run along side cosmos-sdk based validators, it's go only for now, more will be added later as needed 

The PR also adds jester build for Noble, with a fix for an issue with the modfile parser due to unknown block types