### PR TITLE
feat(sei): ship libevmone alongside seid for Giga executor (v6.5.2+)

### DIFF
--- a/chains/sei.yaml
+++ b/chains/sei.yaml
@@ -12,5 +12,10 @@
     # Keep parity with sei-builds-seid Makefile extraction logic.
     - /build/sei-chain/sei-wasmvm/internal/api/libwasmvm*.so
     - /build/sei-chain/sei-wasmd/x/wasm/artifacts/v*/api/libwasmvm*.so
+  directories:
+    # Giga executor (v6.5.2+) loads libevmone via runtime.Caller(0) at the
+    # build-time source path. Preserve the absolute build path in the final
+    # image so evmc.Load() can find /build/sei-chain/giga/executor/lib/libevmone*.so.
+    - /build/sei-chain/giga/executor/lib
   platforms:
     - linux/amd64


### PR DESCRIPTION
sei-chain `v6.5.2` introduces the Giga executor. Giga loads libevmone via cgo at app.New() using runtime.Caller(0) to resolve the path of `giga/executor/lib/evmlib.go,` then joins libName `("libevmone.0.12.0_linux_amd64.so")` to it. 

The Go runtime embeds the source file's path at compile time, so on our heighliner build the binary tries to dlopen `/build/sei-chain/giga/executor/lib/libevmone.0.12.0_linux_amd64.so` at runtime.