### PR TITLE
fix(story-geth): pin go-version to 1.24 to fix missing alpine image

### DIFF
--- a/.github/workflows/story-geth.yml
+++ b/.github/workflows/story-geth.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "story-geth-v[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Git tag/ref to build (e.g. v1.2.1)'
+        required: false
+        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -38,9 +43,14 @@ jobs:
         run: |
           go build -o heighliner
 
-      - name: Extract version from tag
+      - name: Extract version from tag or input
         id: extract_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/story-geth-}" >> $GITHUB_ENV
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+          else
+            echo "VERSION=${GITHUB_REF#refs/tags/story-geth-}" >> $GITHUB_ENV
+          fi
 
       - name: Manually pull the base Docker image
         run: |
@@ -49,7 +59,7 @@ jobs:
 
       - name: Build and push story-geth Docker image
         run: |
-          ./heighliner build -c story-geth --git-ref ${{ env.VERSION }}
+          ./heighliner build -c story-geth --git-ref ${{ env.VERSION }} --go-version 1.24
 
       - name: Tag and push Docker image
         run: |


### PR DESCRIPTION
## Problem

Building `story-geth-v1.2.1` fails with:

```
error building docker image for story-geth from ref: v1.2.1 - manifest for golang:1.24.0-alpine3.22 not found
```

`piplabs/story-geth` go.mod specifies `go 1.24.0`. Heighliner sees a 3-part version and expands it to `golang:1.24.0-alpine3.22` using the latest alpine. That image does **not** exist on Docker Hub.

## Fix

Add `--go-version 1.24` to the heighliner build command. With a 2-part version heighliner uses its version map, resolving to `golang:1.24.1-alpine3.21` which is a valid image.

Also adds a `version` input to `workflow_dispatch` so the build can be re-triggered for an existing tag without deleting and recreating it.

## Testing

After merge, trigger via:
```
gh workflow run story-geth.yml --repo p2p-org/cosmos-heighliner -f version=v1.2.1
```