### PR TITLE
fix(cosmos): restore Alpine as default final stage, move glibc before it

### DIFF
--- a/dockerfile/cosmos/Dockerfile
+++ b/dockerfile/cosmos/Dockerfile
@@ -147,7 +147,35 @@ FROM ghcr.io/p2p-org/cosmos-heighliner:infra-toolkit-v0.1.6 AS infra-toolkit
 # Use ln and rm from full featured busybox for assembling final image
 FROM busybox:1.34.1-musl AS busybox-full
 
-# Build final image from scratch (Alpine/musl - for binaries built in this image)
+# Optional target for pre-built glibc binaries (e.g. Celestia release binaries that need __isoc23_* from glibc 2.38+).
+# Use: docker build --target glibc ... or heighliner with final-base: glibc in chain config.
+# Single COPY from /root to avoid BuildKit multi-platform "layer does not exist" on separate dir abs copies.
+FROM debian:trixie-slim AS glibc
+
+LABEL org.opencontainers.image.source="https://github.com/p2p-org/cosmos-heighliner"
+
+COPY --from=build-env /root /root
+
+RUN set -eux; \
+  cp -a /root/bin/. /bin/ 2>/dev/null || true; \
+  rm -rf /root/bin; \
+  if [ -d /root/lib ] && [ -n "$(ls -A /root/lib 2>/dev/null)" ]; then cp -a /root/lib/. /lib/; fi; \
+  rm -rf /root/lib; \
+  if [ -s /root/dir_abs.list ]; then \
+    i=0; while read -r DIR; do \
+      [ -z "$DIR" ] && continue; \
+      PLACEDIR="$(dirname "$DIR")"; \
+      mkdir -p "$PLACEDIR"; \
+      mv "/root/dir_abs/$i" "$DIR"; \
+      i=$((i+1)); \
+    done < /root/dir_abs.list; \
+  fi; \
+  rm -rf /root/dir_abs /root/dir_abs.list
+
+WORKDIR /home/p2p
+
+# Build final image from scratch (Alpine/musl - for binaries built in this image).
+# This is the default output stage — chains that need glibc use final-base: glibc in their chain config.
 FROM alpine:3
 
 LABEL org.opencontainers.image.source="https://github.com/p2p-org/cosmos-heighliner"
@@ -221,30 +249,3 @@ COPY --from=build-env /root/lib /lib
 
 WORKDIR /home/p2p
 # USER p2p
-
-# Optional target for pre-built glibc binaries (e.g. Celestia release binaries that need __isoc23_* from glibc 2.38+).
-# Use: docker build --target glibc ... or heighliner with final-base: glibc in chain config.
-# Single COPY from /root to avoid BuildKit multi-platform "layer does not exist" on separate dir_abs copies.
-FROM debian:trixie-slim AS glibc
-
-LABEL org.opencontainers.image.source="https://github.com/p2p-org/cosmos-heighliner"
-
-COPY --from=build-env /root /root
-
-RUN set -eux; \
-  cp -a /root/bin/. /bin/ 2>/dev/null || true; \
-  rm -rf /root/bin; \
-  if [ -d /root/lib ] && [ -n "$(ls -A /root/lib 2>/dev/null)" ]; then cp -a /root/lib/. /lib/; fi; \
-  rm -rf /root/lib; \
-  if [ -s /root/dir_abs.list ]; then \
-    i=0; while read -r DIR; do \
-      [ -z "$DIR" ] && continue; \
-      PLACEDIR="$(dirname "$DIR")"; \
-      mkdir -p "$PLACEDIR"; \
-      mv "/root/dir_abs/$i" "$DIR"; \
-      i=$((i+1)); \
-    done < /root/dir_abs.list; \
-  fi; \
-  rm -rf /root/dir_abs /root/dir_abs.list
-
-WORKDIR /home/p2p

--- a/dockerfile/cosmos/native.Dockerfile
+++ b/dockerfile/cosmos/native.Dockerfile
@@ -122,7 +122,35 @@ FROM ghcr.io/p2p-org/cosmos-heighliner:infra-toolkit-v0.1.6 AS infra-toolkit
 # Use ln and rm from full featured busybox for assembling final image
 FROM busybox:1.34.1-musl AS busybox-full
 
-# Build final image from scratch
+# Optional target for pre-built glibc binaries (e.g. Celestia release binaries that need __isoc23_* from glibc 2.38+).
+# Use: docker build --target glibc ... or heighliner with final-base: glibc in chain config.
+# Single COPY from /root to avoid BuildKit multi-platform "layer does not exist" on separate dir abs copies.
+FROM debian:trixie-slim AS glibc
+
+LABEL org.opencontainers.image.source="https://github.com/p2p-org/cosmos-heighliner"
+
+COPY --from=build-env /root /root
+
+RUN set -eux; \
+  cp -a /root/bin/. /bin/ 2>/dev/null || true; \
+  rm -rf /root/bin; \
+  if [ -d /root/lib ] && [ -n "$(ls -A /root/lib 2>/dev/null)" ]; then cp -a /root/lib/. /lib/; fi; \
+  rm -rf /root/lib; \
+  if [ -s /root/dir_abs.list ]; then \
+    i=0; while read -r DIR; do \
+      [ -z "$DIR" ] && continue; \
+      PLACEDIR="$(dirname "$DIR")"; \
+      mkdir -p "$PLACEDIR"; \
+      mv "/root/dir_abs/$i" "$DIR"; \
+      i=$((i+1)); \
+    done < /root/dir_abs.list; \
+  fi; \
+  rm -rf /root/dir_abs /root/dir_abs.list
+
+WORKDIR /home/p2p
+
+# Build final image from scratch (Alpine/musl - default for binaries built in this image).
+# This is the default output stage — chains that need glibc use final-base: glibc in their chain config.
 FROM alpine:3
 
 LABEL org.opencontainers.image.source="https://github.com/p2p-org/cosmos-heighliner"
@@ -202,30 +230,3 @@ RUN apk update && \
 
 WORKDIR /home/p2p
 # USER p2p
-
-# Optional target for pre-built glibc binaries (e.g. Celestia release binaries that need __isoc23_* from glibc 2.38+).
-# Use: docker build --target glibc ... or heighliner with final-base: glibc in chain config.
-# Single COPY from /root to avoid BuildKit multi-platform "layer does not exist" on separate dir_abs copies.
-FROM debian:trixie-slim AS glibc
-
-LABEL org.opencontainers.image.source="https://github.com/p2p-org/cosmos-heighliner"
-
-COPY --from=build-env /root /root
-
-RUN set -eux; \
-  cp -a /root/bin/. /bin/ 2>/dev/null || true; \
-  rm -rf /root/bin; \
-  if [ -d /root/lib ] && [ -n "$(ls -A /root/lib 2>/dev/null)" ]; then cp -a /root/lib/. /lib/; fi; \
-  rm -rf /root/lib; \
-  if [ -s /root/dir_abs.list ]; then \
-    i=0; while read -r DIR; do \
-      [ -z "$DIR" ] && continue; \
-      PLACEDIR="$(dirname "$DIR")"; \
-      mkdir -p "$PLACEDIR"; \
-      mv "/root/dir_abs/$i" "$DIR"; \
-      i=$((i+1)); \
-    done < /root/dir_abs.list; \
-  fi; \
-  rm -rf /root/dir_abs /root/dir_abs.list
-
-WORKDIR /home/p2p


### PR DESCRIPTION
## Fix

Move the `glibc` stage **before** the Alpine stage in both Dockerfiles so Alpine is the last (default) output stage again. Chains that need glibc (Celestia) continue to work via their explicit `final-base: glibc` config.